### PR TITLE
Fix a issue when player owns a trap and enters another world (can't meaure distance between worlds)

### DIFF
--- a/EnchantTrapPack/src/com/sucy/trap/enchant/Trap.java
+++ b/EnchantTrapPack/src/com/sucy/trap/enchant/Trap.java
@@ -158,6 +158,7 @@ public class Trap {
         enchantment.onUpdate(this, level);
         if (owner == null) remove();
         else if (!owner.isOnline()) remove();
+		else if (!owner.getWorld ==location.getWorld()) remove();
         else if (owner.getLocation().distanceSquared(center) > MAX_DISTANCE * MAX_DISTANCE) remove();
         lifespan--;
         if (lifespan == 0) remove();


### PR DESCRIPTION
Removes a trap when player is not at original world
